### PR TITLE
build: use Python 3.9 to fix readthedocs issue

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -7,7 +7,7 @@ build:
 
 # Configuration
 python:
-  version: 3.10
+  version: 3.9
   install:
     - requirements: docs/requirements.txt
     - method: pip


### PR DESCRIPTION
When specifying Python 3.10 in .readthedocs.yml, an error is raised in the build: 'AttributeError module types has no attribute UnionType'. A temporary fix to this issue is to use Python 3.9. While not optimal, using 3.9 allows the current package docs to build, the conda environment to resolve, and the package tests to pass.

This commit specifies Python 3.9 in .readthedocs.yml.