### PR TITLE
fix: address pylint messages

### DIFF
--- a/src/gbif_registrar/config.py
+++ b/src/gbif_registrar/config.py
@@ -1,9 +1,12 @@
 """Configuration file for the application"""
 
-username = "ws_client_demo"
-password = "Demo123"
-organization = "0a16da09-7719-40de-8d4f-56a15ed52fb6"
-installation = "92d76df5-3de1-4c89-be03-7a17abad962a"
-gbif_api = "http://api.gbif-uat.org/v1/dataset"
-registry_header = "https://registry.gbif-uat.org/dataset"
-local_environment = "https://pasta-s.lternet.edu"  # Can be: "https://pasta.lternet.edu" or "https://pasta-s.lternet.edu"
+USER_NAME = "ws_client_demo"
+PASSWORD = "Demo123"
+ORGANIZATION = "0a16da09-7719-40de-8d4f-56a15ed52fb6"
+INSTALLATION = "92d76df5-3de1-4c89-be03-7a17abad962a"
+GBIF_API = "http://api.gbif-uat.org/v1/dataset"
+REGISTRY_BASE_URL = "https://registry.gbif-uat.org/dataset"
+
+# PASTA_ENVIRONMENT can be: "https://pasta.lternet.edu" or
+# "https://pasta-s.lternet.edu"
+PASTA_ENVIRONMENT = "https://pasta-s.lternet.edu"

--- a/src/gbif_registrar/crawl.py
+++ b/src/gbif_registrar/crawl.py
@@ -2,7 +2,7 @@
 
 import json
 from requests import post, get, delete
-from gbif_registrar.config import username, password, gbif_api, registry_header
+from gbif_registrar.config import USER_NAME, PASSWORD, GBIF_API, REGISTRY_BASE_URL
 from gbif_registrar.utilities import read_local_dataset_metadata
 
 
@@ -29,7 +29,7 @@ def initiate_crawl(local_dataset_id, local_dataset_endpoint, gbif_dataset_uuid):
     """
     # Notify user of the dataset being crawled and provide link to the dataset
     # registry for details and troubleshooting.
-    dataset_registry_url = registry_header + "/" + gbif_dataset_uuid
+    dataset_registry_url = REGISTRY_BASE_URL + "/" + gbif_dataset_uuid
     print(
         "Initiating crawl for EDI dataset '"
         + local_dataset_id
@@ -53,11 +53,7 @@ def initiate_crawl(local_dataset_id, local_dataset_endpoint, gbif_dataset_uuid):
     # Post a new metadata document to update the GBIF landing page. This is
     # necessary because GBIF doesn't "re-crawl" the local dataset metadata when
     # the new local dataset endpoint is updated.
-    # TODO: Call if is an update, not a new dataset?
     post_new_metadata_document(local_dataset_id, gbif_dataset_uuid)
-
-    # TODO: Add datetime to log if successful.
-    return None
 
 
 def post_new_metadata_document(local_dataset_id, gbif_dataset_uuid):
@@ -79,13 +75,13 @@ def post_new_metadata_document(local_dataset_id, gbif_dataset_uuid):
     """
     metadata = read_local_dataset_metadata(local_dataset_id)
     resp = post(
-        gbif_api + "/" + gbif_dataset_uuid + "/document",
+        GBIF_API + "/" + gbif_dataset_uuid + "/document",
         data=metadata,
-        auth=(username, password),
+        auth=(USER_NAME, PASSWORD),
         headers={"Content-Type": "application/xml"},
+        timeout=60,
     )
     resp.raise_for_status()
-    return None
 
 
 def post_local_dataset_endpoint(local_dataset_endpoint, gbif_dataset_uuid):
@@ -107,14 +103,13 @@ def post_local_dataset_endpoint(local_dataset_endpoint, gbif_dataset_uuid):
         Will raise an exception if the POST fails."""
     my_endpoint = {"url": local_dataset_endpoint, "type": "DWC_ARCHIVE"}
     resp = post(
-        gbif_api + "/" + gbif_dataset_uuid + "/endpoint",
+        GBIF_API + "/" + gbif_dataset_uuid + "/endpoint",
         data=json.dumps(my_endpoint),
-        auth=(username, password),
+        auth=(USER_NAME, PASSWORD),
         headers={"Content-Type": "application/json"},
+        timeout=60,
     )
     resp.raise_for_status()
-    # TODO: Add datetime to log if successful.
-    return None
 
 
 def delete_local_dataset_endpoints(gbif_dataset_uuid):
@@ -132,9 +127,10 @@ def delete_local_dataset_endpoints(gbif_dataset_uuid):
     """
     # Get the list of existing endpoints to delete
     endpoints = get(
-        gbif_api + "/" + gbif_dataset_uuid + "/endpoint",
-        auth=(username, password),
+        GBIF_API + "/" + gbif_dataset_uuid + "/endpoint",
+        auth=(USER_NAME, PASSWORD),
         headers={"Content-Type": "application/json"},
+        timeout=60,
     )
     endpoints.raise_for_status()
 
@@ -143,9 +139,9 @@ def delete_local_dataset_endpoints(gbif_dataset_uuid):
         for item in endpoints.json():
             key = item.get("key")
             resp = delete(
-                gbif_api + "/" + gbif_dataset_uuid + "/endpoint/" + str(key),
-                auth=(username, password),
+                GBIF_API + "/" + gbif_dataset_uuid + "/endpoint/" + str(key),
+                auth=(USER_NAME, PASSWORD),
                 headers={"Content-Type": "application/json"},
+                timeout=60,
             )
             resp.raise_for_status()
-    return None

--- a/src/gbif_registrar/utilities.py
+++ b/src/gbif_registrar/utilities.py
@@ -2,7 +2,7 @@
 import os.path
 import pandas as pd
 from requests import get
-from gbif_registrar.config import local_environment
+from gbif_registrar.config import PASTA_ENVIRONMENT
 
 
 def initialize_registrations(file_path):
@@ -41,15 +41,8 @@ def initialize_registrations(file_path):
     if os.path.exists(file_path):
         pass
     else:
-        cols = [
-            "local_dataset_id",
-            "local_dataset_group_id",
-            "local_dataset_endpoint",
-            "gbif_dataset_uuid",
-            "gbif_endpoint_set_datetime",
-        ]
-        df = pd.DataFrame(columns=cols)
-        df.to_csv(file_path, index=False, mode="x")
+        data = pd.DataFrame(columns=expected_cols())
+        data.to_csv(file_path, index=False, mode="x")
 
 
 def read_registrations(file_path):
@@ -105,7 +98,7 @@ def read_local_dataset_metadata(local_dataset_id):
     """
     # Build URL for metadata document to be read
     metadata_url = (
-        local_environment
+        PASTA_ENVIRONMENT
         + "/package/metadata/eml/"
         + local_dataset_id.split(".")[0]
         + "/"
@@ -115,6 +108,6 @@ def read_local_dataset_metadata(local_dataset_id):
     )
 
     # Read metadata document and convert to string for return
-    resp = get(metadata_url)
+    resp = get(metadata_url, timeout=60)
     resp.raise_for_status()
     return resp.text

--- a/src/gbif_registrar/validate.py
+++ b/src/gbif_registrar/validate.py
@@ -68,14 +68,14 @@ def check_local_dataset_id(rgstrs):
         warnings.warn("Duplicate local_dataset_id values in rows: " + ", ".join(dupes))
 
 
-def check_one_to_one_cardinality(df, col1, col2):
+def check_one_to_one_cardinality(data, col1, col2):
     """Check for one-to-one cardinality between two columns of a dataframe.
 
     This is a helper function used in a couple registration checks.
 
     Parameters
     ----------
-    df : pandas.DataFrame
+    data : pandas.DataFrame
     col1 : str
         Column name
     col2 : str
@@ -93,11 +93,11 @@ def check_one_to_one_cardinality(df, col1, col2):
     --------
     >>> rgstrs = read_registrations('tests/registrations.csv')
     >>> check_one_to_one_cardinality( \
-        df=rgstrs, col1='local_dataset_id', col2='local_dataset_endpoint' \
+        data=rgstrs, col1='local_dataset_id', col2='local_dataset_endpoint' \
     )
     """
-    df = df[[col1, col2]].drop_duplicates()
-    group_counts = pd.concat([df[col1].value_counts(), df[col2].value_counts()])
+    data = data[[col1, col2]].drop_duplicates()
+    group_counts = pd.concat([data[col1].value_counts(), data[col2].value_counts()])
     replicates = group_counts > 1
     if any(replicates):
         msg = (
@@ -138,7 +138,7 @@ def check_group_registrations(rgstrs):
     >>> check_group_registrations(rgstrs)
     """
     check_one_to_one_cardinality(
-        df=rgstrs, col1="local_dataset_group_id", col2="gbif_dataset_uuid"
+        data=rgstrs, col1="local_dataset_group_id", col2="gbif_dataset_uuid"
     )
 
 
@@ -169,7 +169,7 @@ def check_local_endpoints(rgstrs):
     >>> check_local_endpoints(rgstrs)
     """
     check_one_to_one_cardinality(
-        df=rgstrs, col1="local_dataset_id", col2="local_dataset_endpoint"
+        data=rgstrs, col1="local_dataset_id", col2="local_dataset_endpoint"
     )
 
 

--- a/tests/test_crawl.py
+++ b/tests/test_crawl.py
@@ -1,3 +1,5 @@
+"""Test crawl.py"""
+
 import pytest
 from gbif_registrar.crawl import initiate_crawl
 from gbif_registrar.register import request_gbif_dataset_uuid
@@ -5,6 +7,7 @@ from gbif_registrar.crawl import post_new_metadata_document
 
 
 def test_initiate_crawl():
+    """Test that the initiate_crawl function works as expected."""
     # TODO: Mock this test
     # local_dataset_endpoint = "https://pasta-s.lternet.edu/package/download/eml/edi/941/3"
     # local_dataset_id = "edi.941.3"

--- a/tests/test_register.py
+++ b/tests/test_register.py
@@ -8,20 +8,18 @@ from gbif_registrar.register import register
 from gbif_registrar.register import request_gbif_dataset_uuid
 
 
-@pytest.fixture
-def rgstrs():
+@pytest.fixture(name="rgstrs")
+def rgstrs_fixture():
     """Read the test registrations file into DataFrame fixture."""
-    rgstrs = read_registrations("tests/registrations.csv")
-    return rgstrs
+    return read_registrations("tests/registrations.csv")
 
 
-@pytest.fixture
-def local_dataset_id():
+@pytest.fixture(name="local_dataset_id")
+def local_dataset_id_fixture():
     """Create a local_dataset_id fixture for tests."""
     # This local_dataset_id corresponds to a data package archived on EDI and
     # formatted according to the DwCA-Event core.
-    local_dataset_id = "edi.929.2"
-    return local_dataset_id
+    return "edi.929.2"
 
 
 @pytest.fixture
@@ -31,8 +29,7 @@ def local_dataset_group_id():
     # EDI and formatted according to the DwCA-Event core. This value is
     # derived from the local_dataset_id fixture and should be the same as the
     # local_dataset_id with the version number removed.
-    local_dataset_group_id = "edi.929"
-    return local_dataset_group_id
+    return "edi.929"
 
 
 def test_get_local_dataset_group_id(local_dataset_id):
@@ -75,15 +72,15 @@ def test_get_gbif_dataset_uuid(rgstrs):
     # res = get_gbif_dataset_uuid(local_dataset_group_id, rgstrs)
 
 
-def test_request_gbif_dataset_uuid(local_dataset_id):
+def test_request_gbif_dataset_uuid():
     """Test request_gbif_dataset_uuid() function.
 
     The expected value is a UUID string on success or None in the case of a
     failed HTTP request."""
     # Case 1: UUID is returned.
     res = request_gbif_dataset_uuid()
-    assert type(res) == str
-    assert type(res) is not None
+    assert isinstance(res, str)
+    assert res is not None
     # Case 2: HTTP request fails.
     # TODO: Stub out the GBIF API call to test this case.
     # res = request_gbif_dataset_uuid()

--- a/tests/test_utilities.py
+++ b/tests/test_utilities.py
@@ -10,35 +10,28 @@ from gbif_registrar.utilities import read_local_dataset_metadata
 
 def test_initialize_registrations_writes_to_path(tmp_path):
     """File is written to path."""
-    f = tmp_path / "registrations.csv"
-    initialize_registrations(f)
-    assert os.path.exists(f)
+    file = tmp_path / "registrations.csv"
+    initialize_registrations(file)
+    assert os.path.exists(file)
 
 
 def test_initialize_registrations_does_not_overwrite(tmp_path):
     """Does not overwrite."""
-    f = tmp_path / "registrations.csv"
-    initialize_registrations(f)
-    with open(f, "rb") as rgstrs:
+    file = tmp_path / "registrations.csv"
+    initialize_registrations(file)
+    with open(file, "rb") as rgstrs:
         md5_before = hashlib.md5(rgstrs.read()).hexdigest()
-    with open(f, "rb") as rgstrs:
+    with open(file, "rb") as rgstrs:
         md5_after = hashlib.md5(rgstrs.read()).hexdigest()
     assert md5_before == md5_after
 
 
 def test_initialize_registrations_has_expected_columns(tmp_path):
     """Has expected columns."""
-    expected_cols = {
-        "local_dataset_id",
-        "local_dataset_group_id",
-        "local_dataset_endpoint",
-        "gbif_dataset_uuid",
-        "gbif_endpoint_set_datetime",
-    }
-    f = tmp_path / "registrations.csv"
-    initialize_registrations(f)
-    df = pd.read_csv(f, delimiter=",")
-    missing_cols = not expected_cols.issubset(set(df.columns))
+    file = tmp_path / "registrations.csv"
+    initialize_registrations(file)
+    data = pd.read_csv(file, delimiter=",")
+    missing_cols = not set(expected_cols()).issubset(set(data.columns))
     assert not missing_cols
 
 
@@ -53,18 +46,6 @@ def test_read_registrations_formats_datetime():
     rgstrs = read_registrations("tests/registrations.csv")
     crawl_time = rgstrs["gbif_endpoint_set_datetime"]
     assert pd.core.dtypes.common.is_datetime64_dtype(crawl_time)
-
-
-def test_expected_cols_has_expected_cols():
-    """The expected_cols helper function has the expected column names."""
-    expected = [
-        "local_dataset_id",
-        "local_dataset_group_id",
-        "local_dataset_endpoint",
-        "gbif_dataset_uuid",
-        "gbif_endpoint_set_datetime",
-    ]
-    assert expected == expected_cols()
 
 
 def test_read_local_dataset_metadata_returns_str():

--- a/tests/test_validate.py
+++ b/tests/test_validate.py
@@ -7,58 +7,57 @@ from gbif_registrar import validate
 from gbif_registrar import utilities
 
 
-@pytest.fixture
-def rgstrs():
+@pytest.fixture(name="rgstrs")
+def rgstrs_fixture():
     """Read the test registrations file into DataFrame fixture."""
-    df = utilities.read_registrations("tests/registrations.csv")
-    return df
+    return utilities.read_registrations("tests/registrations.csv")
 
 
 def test_check_completeness_valid(rgstrs):
     """The registrations file is valid, and doesn't throw a warning."""
-    with warnings.catch_warnings(record=True) as w:
+    with warnings.catch_warnings(record=True) as warns:
         warnings.simplefilter("always")
         validate.check_completeness(rgstrs)
-        assert len(w) == 0
+        assert len(warns) == 0
 
 
 def test_check_completeness_warns(rgstrs):
     """An empty value, in a core column, is an incomplete registration."""
     rgstrs.loc[0, "local_dataset_id"] = np.NaN
     rgstrs.loc[2, "local_dataset_endpoint"] = np.NaN
-    with warnings.catch_warnings(record=True) as w:
+    with warnings.catch_warnings(record=True) as warns:
         warnings.simplefilter("always")
         validate.check_completeness(rgstrs)
-        assert "Incomplete registrations" in str(w[0].message)
-        assert "1, 3" in str(w[0].message)
+        assert "Incomplete registrations" in str(warns[0].message)
+        assert "1, 3" in str(warns[0].message)
 
 
 def test_check_local_dataset_id_valid(rgstrs):
     """The registrations file is valid, and doesn't throw a warning."""
-    with warnings.catch_warnings(record=True) as w:
+    with warnings.catch_warnings(record=True) as warns:
         warnings.simplefilter("always")
         validate.check_local_dataset_id(rgstrs)
-        assert len(w) == 0
+        assert len(warns) == 0
 
 
 def test_check_local_dataset_id_warns(rgstrs):
     """Non-unique primary keys are an issue, and accompanied by a warning."""
     rgstrs = pd.concat([rgstrs, rgstrs.iloc[[-1]]], ignore_index=True)
-    with warnings.catch_warnings(record=True) as w:
+    with warnings.catch_warnings(record=True) as warns:
         warnings.simplefilter("always")
         validate.check_local_dataset_id(rgstrs)
-        assert "Duplicate local_dataset_id values" in str(w[0].message)
-        assert "5" in str(w[0].message)
+        assert "Duplicate local_dataset_id values" in str(warns[0].message)
+        assert "5" in str(warns[0].message)
 
 
 def test_check_one_to_one_cardinality_valid(rgstrs):
     """The registrations file is valid, and doesn't throw a warning."""
-    with warnings.catch_warnings(record=True) as w:
+    with warnings.catch_warnings(record=True) as warns:
         warnings.simplefilter("always")
         validate.check_one_to_one_cardinality(
-            df=rgstrs, col1="local_dataset_id", col2="local_dataset_endpoint"
+            data=rgstrs, col1="local_dataset_id", col2="local_dataset_endpoint"
         )
-        assert len(w) == 0
+        assert len(warns) == 0
 
 
 def test_check_one_to_one_cardinality_warn(rgstrs):
@@ -66,67 +65,67 @@ def test_check_one_to_one_cardinality_warn(rgstrs):
     corresponding value, or else a warning is issued."""
     rgstrs.loc[0, "local_dataset_id"] = rgstrs.loc[1, "local_dataset_id"]
     rgstrs.loc[2, "local_dataset_endpoint"] = rgstrs.loc[3, "local_dataset_endpoint"]
-    with warnings.catch_warnings(record=True) as w:
+    with warnings.catch_warnings(record=True) as warns:
         warnings.simplefilter("always")
         validate.check_one_to_one_cardinality(
-            df=rgstrs, col1="local_dataset_id", col2="local_dataset_endpoint"
+            data=rgstrs, col1="local_dataset_id", col2="local_dataset_endpoint"
         )
-        assert "should have 1-to-1 cardinality" in str(w[0].message)
-        assert rgstrs.loc[1, "local_dataset_id"] in str(w[0].message)
-        assert rgstrs.loc[3, "local_dataset_endpoint"] in str(w[0].message)
+        assert "should have 1-to-1 cardinality" in str(warns[0].message)
+        assert rgstrs.loc[1, "local_dataset_id"] in str(warns[0].message)
+        assert rgstrs.loc[3, "local_dataset_endpoint"] in str(warns[0].message)
 
 
 def test_check_crawl_datetime_valid(rgstrs):
     """The registrations file is valid, and doesn't throw a warning."""
-    with warnings.catch_warnings(record=True) as w:
+    with warnings.catch_warnings(record=True) as warns:
         warnings.simplefilter("always")
         validate.check_crawl_datetime(rgstrs)
-        assert len(w) == 0
+        assert len(warns) == 0
 
 
 def test_check_crawl_datetime_warn(rgstrs):
     """Uncrawled registrations result in a warning."""
     rgstrs.loc[0, "gbif_endpoint_set_datetime"] = np.nan
     rgstrs.loc[2, "gbif_endpoint_set_datetime"] = np.nan
-    with warnings.catch_warnings(record=True) as w:
+    with warnings.catch_warnings(record=True) as warns:
         warnings.simplefilter("always")
         validate.check_crawl_datetime(rgstrs)
-        assert "Uncrawled registrations in rows" in str(w[0].message)
-        assert "1, 3" in str(w[0].message)
+        assert "Uncrawled registrations in rows" in str(warns[0].message)
+        assert "1, 3" in str(warns[0].message)
 
 
 def test_check_local_dataset_id_format_valid(rgstrs):
     """The registrations file is valid, and doesn't throw a warning."""
-    with warnings.catch_warnings(record=True) as w:
+    with warnings.catch_warnings(record=True) as warns:
         warnings.simplefilter("always")
         validate.check_local_dataset_id_format(rgstrs)
-        assert len(w) == 0
+        assert len(warns) == 0
 
 
 def test_check_local_dataset_id_format_warn(rgstrs):
     """Malformed local dataset ID values issue a warning."""
     rgstrs.loc[0, "local_dataset_id"] = "edi"
     rgstrs.loc[2, "local_dataset_id"] = "knb-lter-msp.1"
-    with warnings.catch_warnings(record=True) as w:
+    with warnings.catch_warnings(record=True) as warns:
         warnings.simplefilter("always")
         validate.check_local_dataset_id_format(rgstrs)
-        assert "Invalid local_dataset_id values in rows" in str(w[0].message)
-        assert "1, 3" in str(w[0].message)
+        assert "Invalid local_dataset_id values in rows" in str(warns[0].message)
+        assert "1, 3" in str(warns[0].message)
 
 
 def test_check_local_dataset_group_id_format_valid(rgstrs):
     """The registrations file is valid, and doesn't throw a warning."""
-    with warnings.catch_warnings(record=True) as w:
+    with warnings.catch_warnings(record=True) as warns:
         warnings.simplefilter("always")
         validate.check_local_dataset_group_id_format(rgstrs)
-        assert len(w) == 0
+        assert len(warns) == 0
 
 
 def test_check_local_dataset_group_id_format_warn(rgstrs):
     """Malformed local dataset group ID values issue a warning."""
     rgstrs.loc[0, "local_dataset_group_id"] = "edi.xxx"
-    with warnings.catch_warnings(record=True) as w:
+    with warnings.catch_warnings(record=True) as warns:
         warnings.simplefilter("always")
         validate.check_local_dataset_group_id_format(rgstrs)
-        assert "Invalid local_dataset_group_id values in rows" in str(w[0].message)
-        assert "1" in str(w[0].message)
+        assert "Invalid local_dataset_group_id values in rows" in str(warns[0].message)
+        assert "1" in str(warns[0].message)


### PR DESCRIPTION
Address lingering pylint messages to adhere to best practices and clean up the message log, which has become quite lengthy.