### PR TITLE
fix: use synchronized dataset for testing

### DIFF
--- a/tests/registrations.csv
+++ b/tests/registrations.csv
@@ -5,4 +5,4 @@ edi.356.1,edi.356,https://pasta.lternet.edu/package/archive/eml/edi/356/1/archiv
 edi.356.2,edi.356,https://pasta.lternet.edu/package/archive/eml/edi/356/2/archive_edi.356.2_74665239205231111,8c30c4a7-2f63-4421-83c0-60f3d3b195b1,2022-12-05 02:00:00
 knb-lter-msp.1.1,knb-lter-msp.1,https://pasta.lternet.edu/package/archive/eml/knb-lter-msp/1/1/archive_knb-lter-msp.1.1_33365239205233345,8c30c4a7-4444-4421-83c0-60f3d3b195b1,2022-12-21 09:00:00
 knb-lter-msp.1.2,knb-lter-msp.1,https://pasta.lternet.edu/package/archive/eml/knb-lter-msp/1/2/archive_knb-lter-msp.1.2_32165239205231111,8c30c4a7-4444-4421-83c0-60f3d3b195b1,2022-12-22 10:00:00
-edi.941.3,edi.941,https://pasta.lternet.edu/package/download/eml/edi/941/3,b155a522-0992-46fa-a8f0-2306c98e6b79,2023-06-22 00:00:00
+edi.941.3,edi.941,https://pasta.lternet.edu/package/download/eml/edi/941/3,cfb3f6d5-ed7d-4fff-9f1b-f032ed1de485,2023-06-22 00:00:00


### PR DESCRIPTION
Add a dataset that has been synchronized between EDI and GBIF to 'registrations.csv' for testing purposes.