### PR TITLE
fix: use PASTA environment consistently

### DIFF
--- a/src/gbif_registrar/crawl.py
+++ b/src/gbif_registrar/crawl.py
@@ -16,8 +16,8 @@ def initiate_crawl(local_dataset_id, local_dataset_endpoint, gbif_dataset_uuid):
         {scope}.{identifier}.{revision}.
     local_dataset_endpoint : str
         This is the URL for downloading the dataset (.zip archive) at the EDI
-        repository. It has the format: https://pasta.lternet.edu/package/
-        download/eml/{scope}/{identifier}/{revision}.
+        repository. This value can be obtained from the
+        get_local_dataset_endpoint function in the utilities module.
     gbif_dataset_uuid : str
         The registration identifier assigned by GBIF to the local dataset
         group.
@@ -92,8 +92,8 @@ def post_local_dataset_endpoint(local_dataset_endpoint, gbif_dataset_uuid):
     ----------
     local_dataset_endpoint : str
         This is the URL for downloading the dataset (.zip archive) at the EDI
-        repository. It has the format: https://pasta.lternet.edu/package/
-        download/eml/{scope}/{identifier}/{revision}.
+        repository. Use the get_local_dataset_endpoint function in the
+        utilities module to obtain this value.
         gbif_dataset_uuid : str
         The registration identifier assigned by GBIF to the local dataset
         group.

--- a/src/gbif_registrar/register.py
+++ b/src/gbif_registrar/register.py
@@ -8,6 +8,7 @@ from gbif_registrar.config import (
     ORGANIZATION,
     PASSWORD,
     USER_NAME,
+    PASTA_ENVIRONMENT,
 )
 from gbif_registrar.utilities import read_registrations
 
@@ -172,8 +173,15 @@ def get_local_dataset_endpoint(local_dataset_id):
     scope = local_dataset_id.split(".")[0]
     identifier = local_dataset_id.split(".")[1]
     revision = local_dataset_id.split(".")[2]
-    base_url = "https://pasta.lternet.edu/package/download/eml/"
-    local_dataset_id = base_url + scope + "/" + identifier + "/" + revision
+    local_dataset_id = (
+        PASTA_ENVIRONMENT
+        + "/package/download/eml/"
+        + scope
+        + "/"
+        + identifier
+        + "/"
+        + revision
+    )
     return local_dataset_id
 
 

--- a/tests/test_register.py
+++ b/tests/test_register.py
@@ -6,6 +6,7 @@ from gbif_registrar.register import get_local_dataset_endpoint
 from gbif_registrar.register import get_gbif_dataset_uuid
 from gbif_registrar.register import register
 from gbif_registrar.register import request_gbif_dataset_uuid
+from gbif_registrar.config import PASTA_ENVIRONMENT
 
 
 @pytest.fixture(name="rgstrs")
@@ -63,7 +64,7 @@ def test_get_local_dataset_endpoint(local_dataset_id):
     repository Download Data Package Archive endpoint and the local dataset ID
     value broken into scope, identifier, and version."""
     res = get_local_dataset_endpoint(local_dataset_id)
-    expected = "https://pasta.lternet.edu/package/download/eml/edi/929/2"
+    expected = PASTA_ENVIRONMENT + "/package/download/eml/edi/929/2"
     assert res == expected
 
 


### PR DESCRIPTION
Use the PASTA_ENVIRONMENT variable to ensure consistent alignment of data package references. Using different environments results in data package reference mismatches and various errors throughout the application code.