### PR TITLE
feat: wrap get GBIF dataset details for general use

### DIFF
--- a/src/gbif_registrar/utilities.py
+++ b/src/gbif_registrar/utilities.py
@@ -140,3 +140,24 @@ def has_metadata(gbif_dataset_uuid):
         return False
     details = loads(resp.text)
     return bool(details.get("title"))
+
+
+def get_gbif_dataset_details(gbif_dataset_uuid):
+    """Get the details of a GBIF dataset.
+
+    Parameters
+    ----------
+    gbif_dataset_uuid : str
+        The registration identifier assigned by GBIF to the local dataset.
+
+    Returns
+    -------
+    dict
+        A dictionary containing the details of the GBIF dataset.
+    """
+    resp = requests.get(url=GBIF_API + "/" + gbif_dataset_uuid, timeout=60)
+    if resp.status_code != 200:
+        print("HTTP request failed with status code: " + str(resp.status_code))
+        print(resp.reason)
+        return None
+    return loads(resp.text)

--- a/tests/test_utilities.py
+++ b/tests/test_utilities.py
@@ -8,6 +8,7 @@ from gbif_registrar.utilities import initialize_registrations
 from gbif_registrar.utilities import expected_cols
 from gbif_registrar.utilities import read_local_dataset_metadata
 from gbif_registrar.utilities import has_metadata
+from gbif_registrar.utilities import get_gbif_dataset_details
 
 
 @pytest.fixture(name="eml")
@@ -123,3 +124,23 @@ def test_has_metadata_failure(mocker):
     mocker.patch("requests.get", return_value=mock_response)
     res = has_metadata("cfb3f6d5-ed7d-4fff-9f1b-f032ed1de485")
     assert res is False
+
+
+def test_get_gbif_dataset_details_success(mocker):
+    """Test that get_gbif_dataset_details returns a dict on success."""
+    mock_response = mocker.Mock()
+    mock_response.status_code = 200
+    mock_response.text = """{"title":"This is a title"}"""
+    mocker.patch("requests.get", return_value=mock_response)
+    res = get_gbif_dataset_details("cfb3f6d5-ed7d-4fff-9f1b-f032ed1de485")
+    assert isinstance(res, dict)
+
+
+def test_get_gbif_dataset_details_failure(mocker):
+    """Test that get_gbif_dataset_details returns None on failure."""
+    mock_response = mocker.Mock()
+    mock_response.status_code = 404
+    mock_response.reason = "Not Found"
+    mocker.patch("requests.get", return_value=mock_response)
+    res = get_gbif_dataset_details("cfb3f6d5-ed7d-4fff-9f1b-f032e")
+    assert res is None


### PR DESCRIPTION
Wrap calls for GBIF dataset details to simplify response handling and to be DRY when calling from different contexts.