### PR TITLE
refactor: apply read_gbif_dataset_metadata

### DIFF
--- a/src/gbif_registrar/utilities.py
+++ b/src/gbif_registrar/utilities.py
@@ -133,13 +133,10 @@ def has_metadata(gbif_dataset_uuid):
     The presence of a dataset title indicates that the dataset has been
     crawled by GBIF and the metadata document has been created.
     """
-    resp = requests.get(url=GBIF_API + "/" + gbif_dataset_uuid, timeout=60)
-    if resp.status_code != 200:
-        print("HTTP request failed with status code: " + str(resp.status_code))
-        print(resp.reason)
-        return False
-    details = loads(resp.text)
-    return bool(details.get("title"))
+    metadata = read_gbif_dataset_metadata(gbif_dataset_uuid)
+    if metadata:
+        return bool(metadata.get("title"))
+    return False
 
 
 def read_gbif_dataset_metadata(gbif_dataset_uuid):

--- a/tests/test_utilities.py
+++ b/tests/test_utilities.py
@@ -1,6 +1,7 @@
 """Test utilities"""
 import os.path
 import hashlib
+from json import loads
 import pytest
 import pandas as pd
 from gbif_registrar.utilities import read_registrations
@@ -91,12 +92,11 @@ def test_read_local_dataset_metadata_failure(mocker):
 
 def test_has_metadata_success(mocker):
     """Test that has_metadata returns True on success."""
-    # Create a JSON string simulating a successful response from the GBIF API
-    json_content = """{"title":"This is a title"}"""
-    mock_response = mocker.Mock()
-    mock_response.status_code = 200
-    mock_response.text = json_content
-    mocker.patch("requests.get", return_value=mock_response)
+    mock_response = loads("""{"title":"This is a title"}""")
+    mocker.patch(
+        "gbif_registrar.utilities.read_gbif_dataset_metadata",
+        return_value=mock_response,
+    )
     res = has_metadata("cfb3f6d5-ed7d-4fff-9f1b-f032ed1de485")
     assert isinstance(res, bool)
 
@@ -104,24 +104,24 @@ def test_has_metadata_success(mocker):
 def test_has_metadata_failure(mocker):
     """Test that has_metadata returns False on failure.
 
-    Failure may occur if the GBIF API returns a 404 status code or if the
-    JSON response doesn't contain a title."""
+    Failure occurs if the response doesn't contain a title or the response is
+    None."""
 
-    # Case 1: GBIF API returns a 404 status code
-    mock_response = mocker.Mock()
-    mock_response.status_code = 404
-    mock_response.reason = "Not Found"
-    mocker.patch("requests.get", return_value=mock_response)
+    # Case 1: Response from read_gbif_dataset_metadata doesn't contain a title
+    mock_response = loads("""{"description":"This is a description"}""")
+    mocker.patch(
+        "gbif_registrar.utilities.read_gbif_dataset_metadata",
+        return_value=mock_response,
+    )
     res = has_metadata("cfb3f6d5-ed7d-4fff-9f1b-f032ed1de485")
     assert res is False
 
-    # Case 2: GBIF API returns a 200 status code but the JSON response doesn't
-    # contain a title
-    json_content = """{"description":"This is a description"}"""
-    mock_response = mocker.Mock()
-    mock_response.status_code = 200
-    mock_response.text = json_content
-    mocker.patch("requests.get", return_value=mock_response)
+    # Case 2: Response from read_gbif_dataset_metadata is None
+    mock_response = None
+    mocker.patch(
+        "gbif_registrar.utilities.read_gbif_dataset_metadata",
+        return_value=mock_response,
+    )
     res = has_metadata("cfb3f6d5-ed7d-4fff-9f1b-f032ed1de485")
     assert res is False
 


### PR DESCRIPTION
Apply 'read_gbif_dataset_metadata' to functions requiring this information in their custom implementations to maintain a DRY codebase.