### PR TITLE
test: share fixtures with conftest.py

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,73 @@
+"""Configure the test suite."""
+
+import pytest
+from gbif_registrar.utilities import read_registrations
+
+
+@pytest.fixture(name="rgstrs")
+def rgstrs_fixture():
+    """Read the test registrations file into DataFrame fixture."""
+    return read_registrations("tests/registrations.csv")
+
+
+@pytest.fixture(name="local_dataset_id")
+def local_dataset_id_fixture():
+    """Create a local_dataset_id fixture for tests."""
+    # This local_dataset_id corresponds to a data package archived on EDI and
+    # formatted according to the DwCA-Event core.
+    return "edi.929.2"
+
+
+@pytest.fixture
+def local_dataset_group_id():
+    """Create a local_dataset_group_id fixture for tests."""
+    # This local_dataset_group_id corresponds to a data package archived on
+    # EDI and formatted according to the DwCA-Event core. This value is
+    # derived from the local_dataset_id fixture and should be the same as the
+    # local_dataset_id with the version number removed.
+    return "edi.929"
+
+
+@pytest.fixture(name="local_dataset_endpoint")
+def local_dataset_endpoint_fixture():
+    """Create a local_dataset_endpoint fixture for tests."""
+    # This local_dataset_endpoint corresponds to a data package archived on
+    # EDI and formatted according to the DwCA-Event core.
+    return "https://pasta.lternet.edu/package/download/eml/edi/929/2"
+
+
+@pytest.fixture(name="gbif_dataset_uuid")
+def gbif_dataset_uuid_fixture():
+    """Create a gbif_dataset_uuid fixture for tests."""
+    # This gbif_dataset_uuid is an example UUID returned by the GBIF API.
+    return "4e70c80e-cf22-49a5-8bf7-280994500324"
+
+
+@pytest.fixture(name="eml")
+def eml_fixture():
+    """Create an EML XML string for testing."""
+    xml_content = """<?xml version="1.0" encoding="UTF-8"?>
+    <eml:eml packageId="knb-lter-ble.20.1" system="https://pasta-d.lternet.edu" 
+    xmlns:eml="eml://ecoinformatics.org/eml-2.1.1" 
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" 
+    xsi:schemaLocation="eml://ecoinformatics.org/eml-2.1.1 
+    https://pasta.lternet.edu/eml/eml-2.1.1.xsd">
+        <dataset>
+            <title>This is a title</title>
+            <pubDate>2019-08-01</pubDate>
+        </dataset>
+    </eml:eml>
+    """
+    return xml_content
+
+
+@pytest.fixture(name="gbif_metadata")
+def gbif_metadata_fixture():
+    """Create a dict of GBIF metadata for testing."""
+    metadata = {
+        "pubDate": "2019-08-01T00:00:00.000+0000",
+        "endpoints": [
+            {"url": "https://pasta-s.lternet.edu/package/download/eml/edi/941/3"}
+        ],
+    }
+    return metadata

--- a/tests/test_register.py
+++ b/tests/test_register.py
@@ -1,5 +1,5 @@
 """Test register.py"""
-import pytest
+
 from gbif_registrar.utilities import read_registrations
 from gbif_registrar.register import get_local_dataset_group_id
 from gbif_registrar.register import get_local_dataset_endpoint
@@ -7,45 +7,6 @@ from gbif_registrar.register import get_gbif_dataset_uuid
 from gbif_registrar.register import register
 from gbif_registrar.register import request_gbif_dataset_uuid
 from gbif_registrar.config import PASTA_ENVIRONMENT
-
-
-@pytest.fixture(name="rgstrs")
-def rgstrs_fixture():
-    """Read the test registrations file into DataFrame fixture."""
-    return read_registrations("tests/registrations.csv")
-
-
-@pytest.fixture(name="local_dataset_id")
-def local_dataset_id_fixture():
-    """Create a local_dataset_id fixture for tests."""
-    # This local_dataset_id corresponds to a data package archived on EDI and
-    # formatted according to the DwCA-Event core.
-    return "edi.929.2"
-
-
-@pytest.fixture
-def local_dataset_group_id():
-    """Create a local_dataset_group_id fixture for tests."""
-    # This local_dataset_group_id corresponds to a data package archived on
-    # EDI and formatted according to the DwCA-Event core. This value is
-    # derived from the local_dataset_id fixture and should be the same as the
-    # local_dataset_id with the version number removed.
-    return "edi.929"
-
-
-@pytest.fixture(name="local_dataset_endpoint")
-def local_dataset_endpoint_fixture():
-    """Create a local_dataset_endpoint fixture for tests."""
-    # This local_dataset_endpoint corresponds to a data package archived on
-    # EDI and formatted according to the DwCA-Event core.
-    return "https://pasta.lternet.edu/package/download/eml/edi/929/2"
-
-
-@pytest.fixture(name="gbif_dataset_uuid")
-def gbif_dataset_uuid_fixture():
-    """Create a gbif_dataset_uuid fixture for tests."""
-    # This gbif_dataset_uuid is an example UUID returned by the GBIF API.
-    return "4e70c80e-cf22-49a5-8bf7-280994500324"
 
 
 def test_get_local_dataset_group_id(local_dataset_id):

--- a/tests/test_utilities.py
+++ b/tests/test_utilities.py
@@ -1,8 +1,8 @@
 """Test utilities"""
+
 import os.path
 import hashlib
 from json import loads
-import pytest
 import pandas as pd
 from gbif_registrar.utilities import read_registrations
 from gbif_registrar.utilities import initialize_registrations
@@ -11,36 +11,6 @@ from gbif_registrar.utilities import read_local_dataset_metadata
 from gbif_registrar.utilities import has_metadata
 from gbif_registrar.utilities import read_gbif_dataset_metadata
 from gbif_registrar.utilities import is_synchronized
-
-
-@pytest.fixture(name="eml")
-def eml_fixture():
-    """Create an EML XML string for testing."""
-    xml_content = """<?xml version="1.0" encoding="UTF-8"?>
-    <eml:eml packageId="knb-lter-ble.20.1" system="https://pasta-d.lternet.edu" 
-    xmlns:eml="eml://ecoinformatics.org/eml-2.1.1" 
-    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" 
-    xsi:schemaLocation="eml://ecoinformatics.org/eml-2.1.1 
-    https://pasta.lternet.edu/eml/eml-2.1.1.xsd">
-        <dataset>
-            <title>This is a title</title>
-            <pubDate>2019-08-01</pubDate>
-        </dataset>
-    </eml:eml>
-    """
-    return xml_content
-
-
-@pytest.fixture(name="gbif_metadata")
-def gbif_metadata_fixture():
-    """Create a dict of GBIF metadata for testing."""
-    metadata = {
-        "pubDate": "2019-08-01T00:00:00.000+0000",
-        "endpoints": [
-            {"url": "https://pasta-s.lternet.edu/package/download/eml/edi/941/3"}
-        ],
-    }
-    return metadata
 
 
 def test_initialize_registrations_writes_to_path(tmp_path):

--- a/tests/test_validate.py
+++ b/tests/test_validate.py
@@ -1,16 +1,9 @@
 """Test validate"""
+
 import warnings
-import pytest
 import numpy as np
 import pandas as pd
 from gbif_registrar import validate
-from gbif_registrar import utilities
-
-
-@pytest.fixture(name="rgstrs")
-def rgstrs_fixture():
-    """Read the test registrations file into DataFrame fixture."""
-    return utilities.read_registrations("tests/registrations.csv")
 
 
 def test_check_completeness_valid(rgstrs):


### PR DESCRIPTION
Utilize 'conftest.py' for sharing test fixtures, currently isolated within test modules.