### PR TITLE
docs: address RTD build deprecation

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -9,7 +9,6 @@ build:
 
 # Configuration
 python:
-  version: 3.9
   install:
     - requirements: docs/requirements.txt
     - method: pip

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -3,7 +3,9 @@ version: 2
 
 # Image to use
 build:
-  image: testing
+  os: "ubuntu-22.04"
+  tools:
+    python: "3.9"
 
 # Configuration
 python:


### PR DESCRIPTION
Switch to 'build.os' instead of 'build.image' to address the deprecation of the 'build.image' config key in Read the Docs. This change is necessary for successful documentation building.