### PR TITLE
ci: ignore pylint c-extension-no-member messages

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,6 +43,9 @@ upload_to_pypi = false                      # don't auto-upload to PyPI
 remove_dist = false                         # don't remove dists
 patch_without_tag = true                    # patch release by default
 
+[tool.pylint.'MESSAGES CONTROL']
+disable = "c-extension-no-member"
+
 [build-system]
 requires = ["poetry-core>=1.0.0"]
 build-backend = "poetry.core.masonry.api"


### PR DESCRIPTION
Ignore pylint 'c-extension-no-member' (I1101) messages, originating from lxml, for the sake of a readable message log.

Another option, adding lxml to the pylint --extension-pkg-allow-list, may run arbitrary code and is a decision that shouldn't be made for collaborators running pylint in the context of this project.