### PR TITLE
refactor: enhance clarity in read_registrations

### DIFF
--- a/src/gbif_registrar/register.py
+++ b/src/gbif_registrar/register.py
@@ -10,7 +10,7 @@ from gbif_registrar.config import (
     PASSWORD,
     USER_NAME,
 )
-from gbif_registrar.utilities import read_registrations
+from gbif_registrar.utilities import read_registrations_file
 from gbif_registrar.utilities import get_local_dataset_endpoint
 from gbif_registrar.utilities import expected_cols
 
@@ -85,7 +85,7 @@ def register_dataset(local_dataset_id, registrations_file):
     >>> register_dataset("edi.929.2", "registrations.csv")
     """
     # Read the registrations file from the file path parameter
-    registrations = read_registrations(registrations_file)
+    registrations = read_registrations_file(registrations_file)
     # If the local_dataset_id already exists in the registrations file, then
     # return the registrations file as-is and send to complete_registrations
     # function for further processing.

--- a/src/gbif_registrar/utilities.py
+++ b/src/gbif_registrar/utilities.py
@@ -6,25 +6,24 @@ import requests
 from gbif_registrar.config import PASTA_ENVIRONMENT, GBIF_API
 
 
-def read_registrations(file_path):
-    """Reads the registrations file.
+def read_registrations_file(registrations_file):
+    """Return the registrations file as a Pandas dataframe.
 
     Parameters
     ----------
-    file_path : Any
+    registrations_file : str
         Path of the registrations file.
 
     Returns
     -------
     DataFrame
-        Pandas dataframe.
+        The registrations file as a Pandas dataframe.
 
-    See Also
+    Examples
     --------
-    check_registrations_file
+    >>> read_registrations_file("registrations.csv")
     """
-    rgstrs = pd.read_csv(file_path, delimiter=",")
-    return rgstrs
+    return pd.read_csv(registrations_file, delimiter=",")
 
 
 def expected_cols():
@@ -144,7 +143,7 @@ def is_synchronized(local_dataset_id, file_path):
     GBIF instance.
     """
     # Get the gbif_dataset_uuid to use in the GBIF API call.
-    registrations = read_registrations(file_path)
+    registrations = read_registrations_file(file_path)
     gbif_dataset_uuid = registrations.loc[
         registrations["local_dataset_id"] == local_dataset_id, "gbif_dataset_uuid"
     ].values[0]

--- a/src/gbif_registrar/validate.py
+++ b/src/gbif_registrar/validate.py
@@ -1,7 +1,7 @@
 """A module for validating the registrations file"""
 import warnings
 import pandas as pd
-from gbif_registrar.utilities import read_registrations
+from gbif_registrar.utilities import read_registrations_file
 from gbif_registrar.utilities import expected_cols
 
 
@@ -15,7 +15,7 @@ def check_completeness(rgstrs):
     Parameters
     ----------
     rgstrs : pandas.DataFrame
-        A dataframe of the registrations file. Use`read_registrations` to
+        A dataframe of the registrations file. Use`read_registrations_file` to
         create this.
 
     Returns
@@ -58,7 +58,7 @@ def check_local_dataset_id(rgstrs):
 
     Examples
     --------
-    >>> rgstrs = read_registrations('tests/registrations.csv')
+    >>> rgstrs = read_registrations_file('tests/registrations.csv')
     >>> check_local_dataset_id(rgstrs)
     """
     dupes = rgstrs["local_dataset_id"].duplicated()
@@ -91,7 +91,7 @@ def check_one_to_one_cardinality(data, col1, col2):
 
     Examples
     --------
-    >>> rgstrs = read_registrations('tests/registrations.csv')
+    >>> rgstrs = read_registrations_file('tests/registrations.csv')
     >>> check_one_to_one_cardinality( \
         data=rgstrs, col1='local_dataset_id', col2='local_dataset_endpoint' \
     )
@@ -134,7 +134,7 @@ def check_group_registrations(rgstrs):
 
     Examples
     --------
-    >>> rgstrs = read_registrations('tests/registrations.csv')
+    >>> rgstrs = read_registrations_file('tests/registrations.csv')
     >>> check_group_registrations(rgstrs)
     """
     check_one_to_one_cardinality(
@@ -165,7 +165,7 @@ def check_local_endpoints(rgstrs):
 
     Examples
     --------
-    >>> rgstrs = read_registrations('tests/registrations.csv')
+    >>> rgstrs = read_registrations_file('tests/registrations.csv')
     >>> check_local_endpoints(rgstrs)
     """
     check_one_to_one_cardinality(
@@ -197,7 +197,7 @@ def check_is_synchronized(rgstrs):
 
     Examples
     --------
-    >>> rgstrs = read_registrations('tests/registrations.csv')
+    >>> rgstrs = read_registrations_file('tests/registrations.csv')
     >>> check_is_synchronized(rgstrs)
     """
     if not rgstrs["is_synchronized"].all():
@@ -226,7 +226,7 @@ def check_local_dataset_id_format(rgstrs):
 
     Examples
     --------
-    >>> rgstrs = read_registrations('tests/registrations.csv')
+    >>> rgstrs = read_registrations_file('tests/registrations.csv')
     >>> check_local_dataset_id_format(rgstrs)
     """
     ids = rgstrs["local_dataset_id"]
@@ -258,7 +258,7 @@ def check_local_dataset_group_id_format(rgstrs):
 
     Examples
     --------
-    >>> rgstrs = read_registrations('tests/registrations.csv')
+    >>> rgstrs = read_registrations_file('tests/registrations.csv')
     >>> check_local_dataset_group_id_format(rgstrs)
     """
     ids = rgstrs["local_dataset_id"]
@@ -303,7 +303,7 @@ def validate_registrations(file_path, extended_checks=False):
     --------
     >>> validate_registrations('tests/registrations.csv')
     """
-    rgstrs = read_registrations(file_path)
+    rgstrs = read_registrations_file(file_path)
     check_completeness(rgstrs)
     check_local_dataset_id(rgstrs)
     check_group_registrations(rgstrs)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,13 +1,13 @@
 """Configure the test suite."""
 
 import pytest
-from gbif_registrar.utilities import read_registrations
+from gbif_registrar.utilities import read_registrations_file
 
 
 @pytest.fixture(name="rgstrs")
 def rgstrs_fixture():
     """Read the test registrations file into DataFrame fixture."""
-    return read_registrations("tests/registrations.csv")
+    return read_registrations_file("tests/registrations.csv")
 
 
 @pytest.fixture(name="local_dataset_id")

--- a/tests/test_register.py
+++ b/tests/test_register.py
@@ -3,7 +3,7 @@
 import os.path
 import hashlib
 import pandas as pd
-from gbif_registrar.utilities import read_registrations
+from gbif_registrar.utilities import read_registrations_file
 from gbif_registrar.register import get_local_dataset_group_id
 from gbif_registrar.register import get_local_dataset_endpoint
 from gbif_registrar.register import get_gbif_dataset_uuid
@@ -144,7 +144,7 @@ def test_register_dataset_success(
         local_dataset_id=local_dataset_id,
         registrations_file=tmp_path / "registrations.csv",
     )
-    rgstrs_final = read_registrations(tmp_path / "registrations.csv")
+    rgstrs_final = read_registrations_file(tmp_path / "registrations.csv")
     assert rgstrs_final.shape[0] == rgstrs.shape[0] + 1
     assert rgstrs_final.iloc[-1]["local_dataset_id"] == local_dataset_id
     assert rgstrs_final.iloc[-1]["gbif_dataset_uuid"] == gbif_dataset_uuid
@@ -165,20 +165,20 @@ def test_register_dataset_repairs_failed_registration(
         "gbif_registrar.register.get_gbif_dataset_uuid", return_value=gbif_dataset_uuid
     )
 
-    rgstrs_initial = read_registrations("tests/registrations.csv")
+    rgstrs_initial = read_registrations_file("tests/registrations.csv")
     rgstrs_initial.to_csv(tmp_path / "registrations.csv", index=False)
     register_dataset(
         local_dataset_id=local_dataset_id,
         registrations_file=tmp_path / "registrations.csv",
     )
-    rgstrs_initial = read_registrations(tmp_path / "registrations.csv")
+    rgstrs_initial = read_registrations_file(tmp_path / "registrations.csv")
     rgstrs_initial.iloc[-1, -4:] = None
     rgstrs_initial.to_csv(tmp_path / "registrations.csv", index=False)
     register_dataset(
         local_dataset_id=local_dataset_id,
         registrations_file=tmp_path / "registrations.csv",
     )
-    rgstrs_final = read_registrations(tmp_path / "registrations.csv")
+    rgstrs_final = read_registrations_file(tmp_path / "registrations.csv")
     assert rgstrs_final.shape[0] == rgstrs_initial.shape[0]
     assert rgstrs_final.iloc[-1]["local_dataset_id"] == local_dataset_id
     assert rgstrs_final.iloc[-1]["gbif_dataset_uuid"] == gbif_dataset_uuid
@@ -198,11 +198,11 @@ def test_register_dataset_ignores_complete_registrations(tmp_path, rgstrs):
     # so that the test can modify it without affecting the original file.
     rgstrs.to_csv(tmp_path / "registrations.csv", index=False)
 
-    rgstrs_initial = read_registrations("tests/registrations.csv")
+    rgstrs_initial = read_registrations_file("tests/registrations.csv")
     rgstrs_initial.to_csv(tmp_path / "registrations.csv", index=False)
     register_dataset(
         local_dataset_id=None, registrations_file=tmp_path / "registrations.csv"
     )
-    rgstrs_final = read_registrations(tmp_path / "registrations.csv")
+    rgstrs_final = read_registrations_file(tmp_path / "registrations.csv")
     assert rgstrs_final.shape[0] == rgstrs_initial.shape[0]
     assert rgstrs_final.equals(rgstrs_initial)

--- a/tests/test_utilities.py
+++ b/tests/test_utilities.py
@@ -2,7 +2,7 @@
 
 from json import loads
 import pandas as pd
-from gbif_registrar.utilities import read_registrations
+from gbif_registrar.utilities import read_registrations_file
 from gbif_registrar.utilities import read_local_dataset_metadata
 from gbif_registrar.utilities import has_metadata
 from gbif_registrar.utilities import read_gbif_dataset_metadata
@@ -11,7 +11,7 @@ from gbif_registrar.utilities import is_synchronized
 
 def test_read_registrations_reads_file():
     """Reads the file."""
-    rgstrs = read_registrations("tests/registrations.csv")
+    rgstrs = read_registrations_file("tests/registrations.csv")
     assert isinstance(rgstrs, pd.DataFrame)
 
 
@@ -93,7 +93,7 @@ def test_read_gbif_dataset_metadata_failure(mocker):
 
 def test_is_synchronized_success(tmp_path, mocker, eml, gbif_metadata):
     """Test that is_synchronized returns True on success."""
-    registrations = read_registrations("tests/registrations.csv")
+    registrations = read_registrations_file("tests/registrations.csv")
     # Add new line to registrations with a dataset that is synchronized with
     # GBIF so that is_synchronized can access this information via the
     # registrations_file argument.
@@ -127,7 +127,7 @@ def test_is_synchronized_success(tmp_path, mocker, eml, gbif_metadata):
 
 def test_is_synchronized_failure(tmp_path, mocker, eml, gbif_metadata):
     """Test that is_synchronized returns False on failure."""
-    registrations = read_registrations("tests/registrations.csv")
+    registrations = read_registrations_file("tests/registrations.csv")
     registrations.to_csv(tmp_path / "registrations.csv", index=False)
     local_dataset_id = "edi.941.3"
     # Mock the response from read_local_dataset_metadata and


### PR DESCRIPTION
Rename the 'read_registrations' function and the 'file_path' parameter to indicate that the registrations file is being read, and to follow a consistent call pattern being implemented throughout the codebase.