### PR TITLE
refactor: default synchronization value to 'False'

### DIFF
--- a/src/gbif_registrar/register.py
+++ b/src/gbif_registrar/register.py
@@ -104,7 +104,7 @@ def register_dataset(local_dataset_id, registrations_file):
                 "local_dataset_group_id": None,
                 "local_dataset_endpoint": None,
                 "gbif_dataset_uuid": None,
-                "is_synchronized": None,
+                "is_synchronized": False,
             },
             index=[0],
         )
@@ -149,7 +149,6 @@ def complete_registration_records(registrations_file):
         (registrations["local_dataset_group_id"].isnull())
         | (registrations["local_dataset_endpoint"].isnull())
         | (registrations["gbif_dataset_uuid"].isnull())
-        | (registrations["is_synchronized"].isnull())
     ]
     # If the record dataframe is empty, then there are no rows to complete.
     # Return the registrations dataframe.

--- a/tests/test_register.py
+++ b/tests/test_register.py
@@ -166,6 +166,7 @@ def test_complete_registration_records_repairs_failed_registration(
     # Simulate a failed registration attempt and write to file for the function
     # to operate on.
     rgstrs.iloc[-1, -4:] = None
+    rgstrs.iloc[-1, -1] = False
     rgstrs.to_csv(tmp_path / "registrations.csv", index=False)
 
     # Run the function and check that the initial and final registrations files


### PR DESCRIPTION
Change the default synchronization indicator from 'None' to 'False' to align the code with example and test usage.