### PR TITLE
fix: resolve reference to dataset group, not endpoint

### DIFF
--- a/src/gbif_registrar/register.py
+++ b/src/gbif_registrar/register.py
@@ -181,7 +181,7 @@ def complete_registration_records(registrations_file):
         if pd.isna(row["gbif_dataset_uuid"]):
             gbif_dataset_uuid = _get_gbif_dataset_uuid(
                 local_dataset_group_id=registrations.loc[
-                    index, "local_dataset_endpoint"
+                    index, "local_dataset_group_id"
                 ],
                 rgstrs=registrations,
             )


### PR DESCRIPTION
To retrieve the corresponding 'gbif_dataset_uuid' without errors, utilize the 'local_dataset_group_id' instead of the 'local_dataset_endpoint.' The 'local_dataset_endpoint' does not reference previously used gbif_dataset_uuid values due to its one-to-one cardinality.