### PR TITLE
refactor: eliminate useless '_has_metadata' function

### DIFF
--- a/src/gbif_registrar/_utilities.py
+++ b/src/gbif_registrar/_utilities.py
@@ -403,30 +403,6 @@ def _get_local_dataset_group_id(local_dataset_id):
     return local_dataset_group_id
 
 
-def _has_metadata(gbif_dataset_uuid):
-    """Check if a GBIF dataset has a metadata document.
-
-    Parameters
-    ----------
-    gbif_dataset_uuid : str
-        The registration identifier assigned by GBIF to the local dataset.
-
-    Returns
-    -------
-    bool
-        True if the dataset has a metadata document, False otherwise.
-
-    Notes
-    -----
-    The presence of a dataset title indicates that the dataset has been
-    crawled by GBIF and the metadata document has been created.
-    """
-    metadata = _read_gbif_dataset_metadata(gbif_dataset_uuid)
-    if metadata:
-        return bool(metadata.get("title"))
-    return False
-
-
 def _is_synchronized(local_dataset_id, file_path):
     """Check if a local dataset is synchronized with the GBIF registry.
 

--- a/tests/test__utilities.py
+++ b/tests/test__utilities.py
@@ -1,12 +1,10 @@
 """Test utilities"""
 
-from json import loads
 import warnings
 import numpy as np
 import pandas as pd
 from gbif_registrar._utilities import (
     _read_local_dataset_metadata,
-    _has_metadata,
     _read_gbif_dataset_metadata,
     _is_synchronized,
     _get_local_dataset_group_id,
@@ -140,42 +138,6 @@ def test_check_local_dataset_group_id_format_warn(rgstrs):
         _check_local_dataset_group_id_format(rgstrs)
         assert "Invalid local_dataset_group_id values in rows" in str(warns[0].message)
         assert "1" in str(warns[0].message)
-
-
-def test_has_metadata_success(mocker):
-    """Test that _has_metadata returns True on success."""
-    mock_response = loads("""{"title":"This is a title"}""")
-    mocker.patch(
-        "gbif_registrar._utilities._read_gbif_dataset_metadata",
-        return_value=mock_response,
-    )
-    res = _has_metadata("cfb3f6d5-ed7d-4fff-9f1b-f032ed1de485")
-    assert isinstance(res, bool)
-
-
-def test_has_metadata_failure(mocker):
-    """Test that _has_metadata returns False on failure.
-
-    Failure occurs if the response doesn't contain a title or the response is
-    None."""
-
-    # Case 1: Response from _read_gbif_dataset_metadata doesn't contain a title
-    mock_response = loads("""{"description":"This is a description"}""")
-    mocker.patch(
-        "gbif_registrar._utilities._read_gbif_dataset_metadata",
-        return_value=mock_response,
-    )
-    res = _has_metadata("cfb3f6d5-ed7d-4fff-9f1b-f032ed1de485")
-    assert res is False
-
-    # Case 2: Response from _read_gbif_dataset_metadata is None
-    mock_response = None
-    mocker.patch(
-        "gbif_registrar._utilities._read_gbif_dataset_metadata",
-        return_value=mock_response,
-    )
-    res = _has_metadata("cfb3f6d5-ed7d-4fff-9f1b-f032ed1de485")
-    assert res is False
 
 
 def test_is_synchronized_success(tmp_path, mocker, eml, gbif_metadata):


### PR DESCRIPTION
Remove the '_has_metadata' function as it does not serve a purpose. Initially, it was designed to determine whether a local dataset group had a member on GBIF and was used to guide decision logic concerning resetting dataset endpoints and re-uploading metadata in the event of a dataset update. However, it became apparent that this function returned
 'True' even if only boilerplate stand-in metadata was posted to GBIF
before the actual metadata was posted during a crawl operation.