### PR TITLE
docs: add examples of public-facing API usage

### DIFF
--- a/src/gbif_registrar/configure.py
+++ b/src/gbif_registrar/configure.py
@@ -23,6 +23,10 @@ def load_configuration(configuration_file):
     -----
     Create a template configuration file with the initialize_configuration_file
     function.
+
+    Examples
+    --------
+    >>> load_configuration("configuration.json")
     """
     with open(configuration_file, "r", encoding="utf-8") as config:
         config = load(config)
@@ -37,6 +41,10 @@ def unload_configuration():
     Returns
     -------
     None
+
+    Examples
+    --------
+    >>> unload_configuration()
     """
     env_vars = [
         "USER_NAME",
@@ -87,6 +95,10 @@ def initialize_configuration_file(file_path):
             The GBIF dataset base URL.
         PASTA_ENVIRONMENT : str
             The PASTA environment base URL.
+
+    Examples
+    --------
+    >>> initialize_configuration_file("configuration.json")
     """
     configuration = {
         "USER_NAME": "ws_client_demo",

--- a/src/gbif_registrar/upload.py
+++ b/src/gbif_registrar/upload.py
@@ -30,6 +30,10 @@ def upload_dataset(local_dataset_id, registrations_file):
 
     This function requires authentication with GBIF. Use the load_configuration
     function from the authenticate module to do this.
+
+    Examples
+    --------
+    >>> upload_dataset("edi.1.1", "registrations.csv")
     """
     print(f"Uploading {local_dataset_id} to GBIF.")
 


### PR DESCRIPTION
Add missing examples of public-facing API usage to provide users with demonstrations of how to use the functions.