### PR TITLE
docs: add blank space for release commit

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,3 +87,4 @@ Interested in contributing? Check out the contributing guidelines. Please note t
 ## License
 
 `gbif_registrar` was created by Colin Smith and Margaret O'Brien. It is licensed under the terms of the MIT license.
+


### PR DESCRIPTION
Insert an empty blank space into the README to ease the creation of a commit message, via Python Semantic Release, intended solely for bumping the major version number.

BREAKING CHANGE: This marks the first fully functioning release of the gbif_registrar package. The APIs of previously released functionality have been considerably modified.