### PR TITLE
ci: update failing GitHub Action workflows

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -16,11 +16,11 @@ jobs:
     steps:
       # Set up job requirements
     - name: Set up Python
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v4
       with:
         python-version: 3.9
     - name: Check-out repository
-      uses: actions/checkout@v2
+      uses: actions/checkout@v4
     - name: Install poetry
       uses: snok/install-poetry@v1
     - name: Install package
@@ -72,12 +72,12 @@ jobs:
     # Define job steps
     steps:
     - name: Set up Python 3.9
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v4
       with:
         python-version: 3.9
 
     - name: Check-out repository
-      uses: actions/checkout@v2
+      uses: actions/checkout@v4
       with:
         fetch-depth: 0
         token: RELEASE_TOKEN


### PR DESCRIPTION
Adjust failing GitHub Actions workflows for 'checkout' and
 'setup-python' used in the CD workflow. This workflow differs from the
CI workflow in that authentication is required for git commit and merging operations.