### PR TITLE
ci: update release token reference

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -80,7 +80,7 @@ jobs:
       uses: actions/checkout@v4
       with:
         fetch-depth: 0
-        token: RELEASE_TOKEN
+        token: GITHUB_TOKEN
 
     - name: Install poetry
       uses: snok/install-poetry@v1


### PR DESCRIPTION
Update the name of the authentication token used by the CD GitHub Actions Workflow to reflect the new permissive permissions set on the default repository token, resolving the CD workflow failure.