### PR TITLE
ci: fix failing release workflow

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -80,7 +80,6 @@ jobs:
       uses: actions/checkout@v4
       with:
         fetch-depth: 0
-        token: GITHUB_TOKEN
 
     - name: Install poetry
       uses: snok/install-poetry@v1
@@ -89,9 +88,12 @@ jobs:
       run: poetry install
 
     - name: Use Python Semantic Release to prepare release
+      env:
+        GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       run: |
           git config user.name github-actions
           git config user.email github-actions@github.com
+          poetry run semantic-release version
           poetry run semantic-release publish
           git checkout development
           git merge main

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,7 +29,7 @@ sphinx-autoapi = "^3.0.0"
 pytest-mock = "^3.12.0"
 
 [tool.semantic_release]
-version_variable = "pyproject.toml:version" # version location
+version_toml = ["pyproject.toml:tool.poetry.version"] # version location
 branch = "main"                             # branch to make releases of
 changelog_file = "CHANGELOG.md"             # changelog file
 build_command = "poetry build"              # build dists


### PR DESCRIPTION
Update the failing release workflow (GitHub Action) to enable Python Semantic Release to automatically create a new release when the development branch is merged into main.

- Add the GITHUB_TOKEN to the semantic release step, where it is necessary for committing changes, using the standard syntax for referencing secrets.
- Include the missing versioning command in the semantic release step to ensure the new version is calculated.
- Correct the outdated syntax for referencing the version number in the pyproject.toml file to align with the requirements of the current version of Python Semantic Release.