### PR TITLE
ci: allow GHA to bypass protection rules on release

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -80,6 +80,7 @@ jobs:
       uses: actions/checkout@v4
       with:
         fetch-depth: 0
+        token: ${{ secrets.RELEASE_TOKEN }}
 
     - name: Install poetry
       uses: snok/install-poetry@v1
@@ -88,8 +89,6 @@ jobs:
       run: poetry install
 
     - name: Use Python Semantic Release to prepare release
-      env:
-        GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       run: |
           git config user.name github-actions
           git config user.email github-actions@github.com


### PR DESCRIPTION
Permit GitHub Actions to bypass repository branch protection rules to enable Python Semantic Release to commit release-related changes back to the main branch.