### PR TITLE
ci: reference missing secret for release

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -89,6 +89,8 @@ jobs:
       run: poetry install
 
     - name: Use Python Semantic Release to prepare release
+      env:
+        GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       run: |
           git config user.name github-actions
           git config user.email github-actions@github.com


### PR DESCRIPTION
Add the missing secret reference (GH_TOKEN) to enable the posting of the release on GitHub.