### PR TITLE
build: configure Read the Docs for explicit path to config.py

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -11,3 +11,6 @@ build:
 python:
   install:
     - requirements: docs/requirements.txt
+
+sphinx:
+  configuration: docs/conf.py


### PR DESCRIPTION
Update `.readthedocs.yaml` to explicitly specify the path to `config.py`. This ensures proper documentation builds and avoids potential issues with an upcoming deprecation of inferred configuration.